### PR TITLE
Corrected Composer package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To install the plugin, follow these instructions.
 
 2. Then tell Composer to load the plugin:
 
-        composer require flipbox/postmark
+        composer require flipboxdigital/postmark
 
 3. In the Control Panel, go to Settings → Plugins and click the “Install” button for Postmark.
 


### PR DESCRIPTION
I couldn't install the plugin through Composer but as it turned out, the package name in the `README` did not match the one in the `composer.json` (and Packagist).