### PR TITLE
Added "type: craft-plugin" to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "flipboxdigital/postmark",
   "description": "Postmark adapter",
+  "type": "craft-plugin",
   "version": "1.0.2",
   "require": {
     "wildbit/swiftmailer-postmark": "^2.1"


### PR DESCRIPTION
Craft's [plugin installer needs](https://github.com/craftcms/plugin-installer/blob/master/src/Installer.php#L35) `"type": "craft-plugin"` in the `composer.json` in order to find Craft plugins, otherwise its installer won't pick up on the new package.